### PR TITLE
Update cats-mtl to 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,8 @@ lazy val effects = crossProject(JSPlatform, JVMPlatform)
   .settings(name := "meow-mtl-effects")
   .settings(commonSettings)
   .settings(libraryDependencies ++= List(
-    "org.typelevel" %%% "cats-effect"   % "2.1.4",
-    "org.typelevel" %%% "cats-effect-laws" % "2.1.4" % Test,
+    "org.typelevel" %%% "cats-effect"   % "2.2.0",
+    "org.typelevel" %%% "cats-effect-laws" % "2.2.0" % Test,
   ))
 
 lazy val monix = crossProject(JSPlatform, JVMPlatform)
@@ -51,7 +51,7 @@ lazy val monix = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings: _*)
   .settings(libraryDependencies ++= List(
     "io.monix" %%% "monix-eval" % "3.2.2",
-    "org.typelevel" %%% "cats-effect-laws" % "2.1.4" % Test,
+    "org.typelevel" %%% "cats-effect-laws" % "2.2.0" % Test,
   ))
 
 def commonSettings = List(
@@ -60,11 +60,11 @@ def commonSettings = List(
   homepage := Some(url("http://github.com/oleg-py/meow-mtl")),
 
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "cats-mtl-core" % "0.7.1",
-    "org.typelevel" %%% "cats-laws"     % "2.1.0" % Test,
+    "org.typelevel" %%% "cats-mtl" % "1.0.0",
+    "org.typelevel" %%% "cats-laws"     % "2.2.0" % Test,
     "io.monix"      %%% "minitest"      % "2.8.2" % Test,
     "io.monix"      %%% "minitest-laws" % "2.8.2" % Test,
-    "org.typelevel" %%% "cats-mtl-laws" % "0.7.1" % Test,
+    "org.typelevel" %%% "cats-mtl-laws" % "1.0.0" % Test,
   ),
 
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),

--- a/core/src/main/scala/com/olegpy/meow/internal/AskOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/AskOptics.scala
@@ -1,16 +1,15 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.ApplicativeAsk
+import cats.mtl.Ask
 import cats.syntax.all._
 import shapeless.Lens
 
 object AskOptics {
   class Applicative[F[_], E, A](
-    parent: ApplicativeAsk[F, E],
+    parent: Ask[F, E],
     lens: Lens[E, A]
-  ) extends ApplicativeAsk[F, A] {
+  ) extends Ask[F, A] {
     implicit val applicative: cats.Applicative[F] = parent.applicative
-    def ask: F[A] = parent.ask map lens.get
-    def reader[B](f: A => B): F[B] = parent.reader(f compose lens.get)
+    def ask[A2 >: A]: F[A2] = parent.ask map lens.get
   }
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/DerivedHierarchy.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/DerivedHierarchy.scala
@@ -9,20 +9,20 @@ private[meow] trait DerivedHierarchy extends DerivedHierarchy.Priority0
 
 private[meow] object DerivedHierarchy {
   trait Priority0 extends Priority1 {
-    implicit def deriveMonadState[F[_], S, A](implicit
+    implicit def deriveStateful[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: MonadState[F, S],
+      parent: Stateful[F, S],
       neq: S =:!= A,
       mkLensToType: MkLensToType[S, A]
-    ): MonadState[F, A] =
+    ): Stateful[F, A] =
       new StateOptics.Monad(parent, mkLensToType())
 
-    implicit def deriveFunctorTell[F[_], S, A](implicit
+    implicit def deriveTell[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: FunctorTell[F, S],
+      parent: Tell[F, S],
       neq: S =:!= A,
       mkPrismToType: MkPrismToType[S, A]
-    ): FunctorTell[F, A] =
+    ): Tell[F, A] =
       new TellOptics.Functor(parent, mkPrismToType())
 
     // A version for concrete F[_]s, but limited to Throwables
@@ -48,12 +48,12 @@ private[meow] object DerivedHierarchy {
   }
 
   trait Priority2 extends Priority3 {
-    implicit def deriveApplicativeAsk[F[_], S, A](implicit
+    implicit def deriveAsk[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: ApplicativeAsk[F, S],
+      parent: Ask[F, S],
       neq: S =:!= A,
       mkLensToType: MkLensToType[S, A]
-    ): ApplicativeAsk[F, A] =
+    ): Ask[F, A] =
       new AskOptics.Applicative(parent, mkLensToType())
 
     implicit def deriveApplicativeError[F[_], S, A](implicit
@@ -64,32 +64,32 @@ private[meow] object DerivedHierarchy {
     ): ApplicativeError[F, A] =
       new RaiseOptics.Applicative(parent, mkPrismToType())
 
-    implicit def deriveApplicativeHandle[F[_], S, A](implicit
+    implicit def deriveHandle[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: ApplicativeHandle[F, S],
+      parent: Handle[F, S],
       neq: S =:!= A,
       mkPrismToType: MkPrismToType[S, A]
-    ): ApplicativeHandle[F, A] =
+    ): Handle[F, A] =
       new HandleOptics.Applicative(parent, mkPrismToType())
   }
 
   trait Priority3 extends Priority4 {
-    implicit def deriveFunctorRaise[F[_], S, A](implicit
+    implicit def deriveRaise[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: FunctorRaise[F, S],
+      parent: Raise[F, S],
       neq: S =:!= A,
       mkPrismToType: MkPrismToType[S, A]
-    ): FunctorRaise[F, A] =
+    ): Raise[F, A] =
       new RaiseOptics.Functor(parent, mkPrismToType())
   }
 
   trait Priority4 {
-    implicit def deriveApplicativeLocal[F[_], S, A](implicit
+    implicit def deriveLocal[F[_], S, A](implicit
       isAbstractF: IsAbstract[F],
-      parent: ApplicativeLocal[F, S],
+      parent: Local[F, S],
       neq: S =:!= A,
       mkLensToType: MkLensToType[S, A]
-    ): ApplicativeLocal[F, A] =
+    ): Local[F, A] =
       new LocalOptics.Applicative(parent, mkLensToType())
   }
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/HandleOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/HandleOptics.scala
@@ -1,14 +1,14 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.{ApplicativeHandle, DefaultApplicativeHandle}
+import cats.mtl.{Handle}
 import com.olegpy.meow.optics.TPrism
 
 
 private[meow] object HandleOptics {
   class Applicative[F[_], S, E](
-    parent: ApplicativeHandle[F, S],
+    parent: Handle[F, S],
     prism: TPrism[S, E]
-  ) extends DefaultApplicativeHandle[F, E] {
+  ) extends Handle[F, E] {
     val applicative: cats.Applicative[F] = parent.applicative
 
     def handleWith[A](fa: F[A])(f: E => F[A]): F[A] =
@@ -17,7 +17,6 @@ private[meow] object HandleOptics {
         case e => parent.raise(e)
       }
 
-    val functor: cats.Functor[F] = parent.functor
-    def raise[A](e: E): F[A] = parent.raise(prism(e))
+    def raise[E2 <: E, A](e: E2): F[A] = parent.raise(prism(e))
   }
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/LocalOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/LocalOptics.scala
@@ -1,17 +1,14 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.ApplicativeLocal
+import cats.mtl.Local
 import shapeless.Lens
-
 
 private[meow] object LocalOptics {
   class Applicative[F[_], E, A](
-    parent: ApplicativeLocal[F, E],
+    parent: Local[F, E],
     lens: Lens[E, A]
-  ) extends AskOptics.Applicative(parent, lens) with ApplicativeLocal[F, A] {
-    def local[B](f: A => A)(fb: F[B]): F[B] =
-      parent.local(lens.modify(_)(f))(fb)
-
-    def scope[B](e: A)(fa: F[B]): F[B] = local(_ => e)(fa)
+  ) extends AskOptics.Applicative(parent, lens) with Local[F, A] {
+    def local[B](fb: F[B])(f: A => A): F[B] =
+      parent.local(fb)(lens.modify(_)(f))
   }
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/ParentInstances.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/ParentInstances.scala
@@ -8,55 +8,55 @@ import shapeless.LowPriority
 private[meow] trait ParentInstances extends ParentInstances1 {
   implicit def monadStateIsMonad[F[_], S](
     implicit LP: LowPriority,
-    MS: MonadState[F, S]
+    MS: Stateful[F, S]
   ): Monad[F] = MS.monad
 }
 
 private[meow] trait ParentInstances1 extends ParentInstances2 {
   implicit def monadChronicleIsMonad[F[_], S](
     implicit LP: LowPriority,
-    MC: MonadChronicle[F, S]
+    MC: Chronicle[F, S]
   ): Monad[F] = MC.monad
 }
 
 private[meow] trait ParentInstances2 extends ParentInstances3 {
   implicit def applicativeHandleIsApplicative[F[_], S](
     implicit LP: LowPriority,
-    AH: ApplicativeHandle[F, S]
+    AH: Handle[F, S]
   ): Applicative[F] = AH.applicative
 }
 
 private[meow] trait ParentInstances3 extends ParentInstances4 {
   implicit def applicativeAskIsApplicative[F[_], S](
     implicit LP: LowPriority,
-    AA: ApplicativeAsk[F, S]
+    AA: Ask[F, S]
   ): Applicative[F] = AA.applicative
 }
 
 private[meow] trait ParentInstances4 extends ParentInstances5 {
   implicit def applicativeLocalIsApplicative[F[_], S](
     implicit LP: LowPriority,
-    AL: ApplicativeLocal[F, S]
+    AL: Local[F, S]
   ): Applicative[F] = AL.applicative
 }
 
 private[meow] trait ParentInstances5 extends ParentInstances6 {
   implicit def functorRaiseIsFunctor[F[_], S](
     implicit LP: LowPriority,
-    FR: FunctorRaise[F, S]
+    FR: Raise[F, S]
   ): Functor[F] = FR.functor
 }
 
 private[meow] trait ParentInstances6 extends ParentInstances7 {
   implicit def functorTellIsFunctor[F[_], S](
     implicit LP: LowPriority,
-    FT: FunctorTell[F, S]
+    FT: Tell[F, S]
   ): Functor[F] = FT.functor
 }
 
 private[meow] trait ParentInstances7 {
   implicit def functorListenIsFunctor[F[_], S](
     implicit LP: LowPriority,
-    FL: FunctorListen[F, S]
+    FL: Listen[F, S]
   ): Functor[F] = FL.functor
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/RaiseOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/RaiseOptics.scala
@@ -1,17 +1,17 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.FunctorRaise
+import cats.mtl.Raise
 import cats.{ApplicativeError, MonadError}
 import com.olegpy.meow.optics.TPrism
 
 
 private[meow] object RaiseOptics {
   class Functor[F[_], S, E](
-    parent: FunctorRaise[F, S],
+    parent: Raise[F, S],
     prism: TPrism[S, E]
-  ) extends FunctorRaise[F, E] {
+  ) extends Raise[F, E] {
     val functor: cats.Functor[F] = parent.functor
-    def raise[A](e: E): F[A] = parent.raise(prism(e))
+    def raise[E2 <: E, A](e: E2): F[A] = parent.raise(prism(e))
   }
 
   class Applicative[F[_], S, E](

--- a/core/src/main/scala/com/olegpy/meow/internal/StateOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/StateOptics.scala
@@ -1,16 +1,18 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.MonadState
+import cats.mtl.Stateful
 import cats.syntax.all._
 import shapeless.Lens
 
 private[meow] object StateOptics {
-  class Monad[F[_], S, A](parent: MonadState[F, S], lens: Lens[S, A])
-    extends MonadState[F, A] {
+  class Monad[F[_], S, A](parent: Stateful[F, S], lens: Lens[S, A])
+    extends Stateful[F, A] {
     implicit val monad: cats.Monad[F] = parent.monad
+
     def get: F[A] = parent.get map lens.get
     def set(a: A): F[Unit] = parent modify (lens.set(_)(a))
-    def inspect[B](f: A => B): F[B] = get map f
-    def modify(f: A => A): F[Unit] = parent modify (lens.modify(_)(f))
+
+    override def inspect[B](f: A => B): F[B] = get map f
+    override def modify(f: A => A): F[Unit] = parent modify (lens.modify(_)(f))
   }
 }

--- a/core/src/main/scala/com/olegpy/meow/internal/TellOptics.scala
+++ b/core/src/main/scala/com/olegpy/meow/internal/TellOptics.scala
@@ -1,14 +1,14 @@
 package com.olegpy.meow.internal
 
-import cats.mtl.{DefaultFunctorTell, FunctorTell}
+import cats.mtl.Tell
 import com.olegpy.meow.optics.TPrism
 
 
 private[meow] object TellOptics {
   class Functor[F[_], S, A](
-    parent: FunctorTell[F, S],
+    parent: Tell[F, S],
     prism: TPrism[S, A]
-  ) extends FunctorTell[F, A] with DefaultFunctorTell[F, A] {
+  ) extends Tell[F, A] {
     val functor: cats.Functor[F] = parent.functor
     def tell(l: A): F[Unit] = parent.tell(prism(l))
   }

--- a/core/src/main/scala/com/olegpy/meow/prelude.scala
+++ b/core/src/main/scala/com/olegpy/meow/prelude.scala
@@ -6,6 +6,6 @@ import com.olegpy.meow.internal.ParentInstances
 /**
  * Import this to have low-priority derivations
  * for base classes of MTL typeclasses
- * (e.g. MonadState => Monad, FunctorRaise => Functor)
+ * (e.g. Stateful => Monad, Raise => Functor)
  */
 object prelude extends ParentInstances

--- a/core/src/test/scala/com/olegpy/meow/derivations/Chaining.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/Chaining.scala
@@ -12,8 +12,8 @@ object Chaining {
   case class StateComponent(nested: (String, Inner))
   case class State(number: Int, other: StateComponent)
 
-  def testState[F[_]](implicit ev: MonadState[F, State]): Unit = {
-    def derives[S](implicit ev: MonadState[F, S]): Unit = ()
+  def testState[F[_]](implicit ev: Stateful[F, State]): Unit = {
+    def derives[S](implicit ev: Stateful[F, S]): Unit = ()
 
     derives[State]
     derives[Inner]
@@ -23,8 +23,8 @@ object Chaining {
     derives[Long]
   }
 
-  def testLocal[F[_]](implicit ev: ApplicativeLocal[F, State]): Unit = {
-    def derives[S](implicit ev: ApplicativeLocal[F, S]): Unit = ()
+  def testLocal[F[_]](implicit ev: Local[F, State]): Unit = {
+    def derives[S](implicit ev: Local[F, S]): Unit = ()
 
     derives[State]
     derives[Inner]
@@ -34,8 +34,8 @@ object Chaining {
     derives[Long]
   }
 
-  def testAsk[F[_]](implicit ev: ApplicativeAsk[F, State]): Unit = {
-    def derives[S](implicit ev: ApplicativeAsk[F, S]): Unit = ()
+  def testAsk[F[_]](implicit ev: Ask[F, State]): Unit = {
+    def derives[S](implicit ev: Ask[F, S]): Unit = ()
 
     derives[State]
     derives[Inner]
@@ -72,8 +72,8 @@ object Chaining {
     derives[String]
   }
 
-  def testFunctorRaise[F[_]](implicit ev: FunctorRaise[F, AppError]): Unit = {
-    def derives[S](implicit ev: FunctorRaise[F, S]): Unit = ()
+  def testRaise[F[_]](implicit ev: Raise[F, AppError]): Unit = {
+    def derives[S](implicit ev: Raise[F, S]): Unit = ()
 
     derives[ADbError]
     derives[DbError]
@@ -82,8 +82,8 @@ object Chaining {
     derives[String]
   }
 
-  def testFunctorTell[F[_]](implicit ev: FunctorTell[F, AppError]): Unit = {
-    def derives[S](implicit ev: FunctorTell[F, S]): Unit = ()
+  def testTell[F[_]](implicit ev: Tell[F, AppError]): Unit = {
+    def derives[S](implicit ev: Tell[F, S]): Unit = ()
 
     derives[ADbError]
     derives[DbError]

--- a/core/src/test/scala/com/olegpy/meow/derivations/Chaining.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/Chaining.scala
@@ -33,17 +33,17 @@ object Chaining {
     derives[Int]
     derives[Long]
   }
+  // todo
+  // def testAsk[F[_]](implicit ev: Ask[F, State]): Unit = {
+  //   def derives[S](implicit ev: Ask[F, S]): Unit = ()
 
-  def testAsk[F[_]](implicit ev: Ask[F, State]): Unit = {
-    def derives[S](implicit ev: Ask[F, S]): Unit = ()
-
-    derives[State]
-    derives[Inner]
-    derives[StateComponent]
-    derives[String]
-    derives[Int]
-    derives[Long]
-  }
+  //   derives[State]
+  //   derives[Inner]
+  //   derives[StateComponent]
+  //   derives[String]
+  //   derives[Int]
+  //   derives[Long]
+  // }
 
   case class DbError(text: String)
   sealed trait NetworkError

--- a/core/src/test/scala/com/olegpy/meow/derivations/DerivedExtraSuite.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/DerivedExtraSuite.scala
@@ -1,7 +1,6 @@
 package com.olegpy.meow.derivations
 
 import cats.mtl.Handle
-import cats.mtl.instances.all._
 import cats.instances.all._
 import cats.syntax.either._
 import com.olegpy.meow.hierarchy._

--- a/core/src/test/scala/com/olegpy/meow/derivations/DerivedExtraSuite.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/DerivedExtraSuite.scala
@@ -1,6 +1,6 @@
 package com.olegpy.meow.derivations
 
-import cats.mtl.ApplicativeHandle
+import cats.mtl.Handle
 import cats.mtl.instances.all._
 import cats.instances.all._
 import cats.syntax.either._
@@ -12,11 +12,11 @@ object DerivedExtraSuite extends SimpleTestSuite {
 
   type Data = Either[String, Int]
 
-  test("ApplicativeHandle.handle totality") {
+  test("Handle.handle totality") {
     type M[A] = Either[Data, A]
 
-    def forStr[F[_] : ApplicativeHandle[*[_], Data]]: ApplicativeHandle[F, String] = implicitly
-    def forInt[F[_] : ApplicativeHandle[*[_], Data]]: ApplicativeHandle[F, Int] = implicitly
+    def forStr[F[_] : Handle[*[_], Data]]: Handle[F, String] = implicitly
+    def forInt[F[_] : Handle[*[_], Data]]: Handle[F, Int] = implicitly
 
     assert(forStr[M].handle(forInt[M].raise(42))(identity) === 42.asRight.asLeft)
   }

--- a/core/src/test/scala/com/olegpy/meow/derivations/DerivedLawsSuite.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/DerivedLawsSuite.scala
@@ -26,29 +26,29 @@ object DerivedLawsSuite extends SimpleTestSuite with Checkers {
 
   type Data = (Long, Int)
 
-  checkAll("MonadState") {
+  checkAll("Stateful") {
     type M[A] = State[Data, A]
-    def derive[F[_]](implicit MS: MonadState[F, Data]): MonadState[F, Int] =
+    def derive[F[_]](implicit MS: Stateful[F, Data]): Stateful[F, Int] =
       implicitly
 
     implicit def eqState[A: Eq]: Eq[M[A]] = Eq.by(_.run((0L, 0)))
-    MonadStateTests(derive[M]).monadState[Int]
+    StatefulTests(derive[M]).monadState[Int]
   }
 
-  checkAll("ApplicativeLocal") {
+  checkAll("Local") {
     type M[A] = Data => A
-    def derive[F[_]](implicit MS: ApplicativeLocal[F, Data]): ApplicativeLocal[F, Int] =
+    def derive[F[_]](implicit MS: Local[F, Data]): Local[F, Int] =
       implicitly
 
-    ApplicativeLocalTests(derive[M]).applicativeLocal[Int, String]
+    LocalTests(derive[M]).applicativeLocal[Int, String]
   }
 
-//  checkAll("ApplicativeAsk") {
+//  checkAll("Ask") {
 //    type M[A] = Data => A
-//    def derive[F[_]](implicit MS: ApplicativeAsk[F, Data]): ApplicativeAsk[F, Int] =
+//    def derive[F[_]](implicit MS: Ask[F, Data]): Ask[F, Int] =
 //      implicitly
 //
-//    ApplicativeAskTests(derive[M]).applicativeAsk[Int]
+//    AskTests(derive[M]).applicativeAsk[Int]
 //  }
 
   type DataC = Either[String, Either[Int, Long]]
@@ -71,12 +71,12 @@ object DerivedLawsSuite extends SimpleTestSuite with Checkers {
     ApplicativeErrorTests(derive[M]).applicativeError[Int, Long, String]
   }
 
-  checkAll("ApplicativeHandle") {
+  checkAll("Handle") {
     type M[A] = Either[DataC, A]
 
-    def derive[F[_]](implicit MS: ApplicativeHandle[F, DataC]): ApplicativeHandle[F, Long] =
+    def derive[F[_]](implicit MS: Handle[F, DataC]): Handle[F, Long] =
       implicitly
 
-    ApplicativeHandleTests(derive[M]).applicativeHandle[Int]
+    HandleTests(derive[M]).applicativeHandle[Int]
   }
 }

--- a/core/src/test/scala/com/olegpy/meow/derivations/Example.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/Example.scala
@@ -2,7 +2,7 @@ package com.olegpy.meow.derivations
 
 import cats._
 import cats.data._
-import cats.mtl.ApplicativeAsk._
+import cats.mtl.Ask._
 import cats.mtl._
 import cats.mtl.instances.all._
 import cats.syntax.flatMap._
@@ -23,17 +23,17 @@ final case class ANetworkError(e: NetworkError) extends AppError
 // This example serves as a compile-time test too.
 object Main {
   def readFromDb[
-  F[_]: Functor : FunctorRaise[*[_], DbError] : ApplicativeAsk[*[_], DbConfig]
+  F[_]: Functor : Raise[*[_], DbError] : Ask[*[_], DbConfig]
   ]: F[String] =
     askF[F]().map(_.dbName)
 
   def sendToNetwork[
-  F[_]: Functor : FunctorRaise[*[_], NetworkError] : ApplicativeAsk[*[_], NetworkConfig]
+  F[_]: Functor : Raise[*[_], NetworkError] : Ask[*[_], NetworkConfig]
   ](s: String): F[Unit] =
     askF[F]().map(_.server + s).map(println)
 
   def readAndSend[
-  F[_]: Monad : FunctorRaise[*[_], AppError] : ApplicativeAsk[*[_], AppConfig]
+  F[_]: Monad : Raise[*[_], AppError] : Ask[*[_], AppConfig]
   ]: F[Unit] = for {
     s <- readFromDb[F]
     _ <- sendToNetwork[F](s)

--- a/core/src/test/scala/com/olegpy/meow/derivations/Example.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/Example.scala
@@ -4,7 +4,6 @@ import cats._
 import cats.data._
 import cats.mtl.Ask._
 import cats.mtl._
-import cats.mtl.instances.all._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.olegpy.meow.hierarchy._
@@ -32,17 +31,19 @@ object Main {
   ](s: String): F[Unit] =
     askF[F]().map(_.server + s).map(println)
 
-  def readAndSend[
-  F[_]: Monad : Raise[*[_], AppError] : Ask[*[_], AppConfig]
-  ]: F[Unit] = for {
-    s <- readFromDb[F]
-    _ <- sendToNetwork[F](s)
-  } yield ()
+  //todo
+  // def readAndSend[
+  // F[_]: Monad : Raise[*[_], AppError] : Ask[*[_], AppConfig]
+  // ]: F[Unit] = for {
+  //   s <- readFromDb[F]
+  //   _ <- sendToNetwork[F](s)
+  // } yield ()
 
   def main(args: Array[String]): Unit = {
     type T[X] = EitherT[Reader[AppConfig, *], AppError, X]
     val start = AppConfig(DbConfig("db"), NetworkConfig("nc"))
-    readAndSend[T].value(start)
+    //todo
+    // readAndSend[T].value(start)
 
     println("hoi")
   }

--- a/core/src/test/scala/com/olegpy/meow/derivations/Prelude.scala
+++ b/core/src/test/scala/com/olegpy/meow/derivations/Prelude.scala
@@ -1,19 +1,19 @@
 package com.olegpy.meow.derivations
 
 import cats.FlatMap
-import cats.mtl.{ApplicativeAsk, MonadState}
+import cats.mtl.{Ask, Stateful}
 
 // Check that syntax is enabled by having just the constraint
 object Prelude {
   import cats.implicits._
   import com.olegpy.meow.prelude._
 
-  def simpleChaining[F[_]](implicit MS: MonadState[F, Int]): F[Int] =
+  def simpleChaining[F[_]](implicit MS: Stateful[F, Int]): F[Int] =
     42.pure[F].flatTap(MS.set)
 
-  def simpleChaining[F[_]: FlatMap](implicit MS: MonadState[F, Int]): F[Int] =
+  def simpleChaining[F[_]: FlatMap](implicit MS: Stateful[F, Int]): F[Int] =
     42.pure[F].flatTap(MS.set)
 
-  def multipleInstances[F[_]](implicit MS: MonadState[F, Int], AA: ApplicativeAsk[F, String]): F[Int] =
+  def multipleInstances[F[_]](implicit MS: Stateful[F, Int], AA: Ask[F, String]): F[Int] =
     42.pure[F]
 }

--- a/effects/src/main/scala/com/olegpy/meow/effects/package.scala
+++ b/effects/src/main/scala/com/olegpy/meow/effects/package.scala
@@ -13,7 +13,7 @@ package object effects {
      * would be a result of function passed to [[runState]].
      *
      * {{{
-     *    def getAndIncrement[F[_]: Apply](implicit MS: MonadState[F, Int]) =
+     *    def getAndIncrement[F[_]: Apply](implicit MS: Stateful[F, Int]) =
      *      MS.get <* MS.modify(_ + 1)
      *
      *
@@ -26,17 +26,17 @@ package object effects {
      *    } yield (out, state) == ("Done", 3)
      * }}}
      */
-    def runState[B](f: MonadState[F, A] => B)(implicit F: Monad[F]): B =
-      f(new RefMonadState(self))
+    def runState[B](f: Stateful[F, A] => B)(implicit F: Monad[F]): B =
+      f(new RefStateful(self))
 
     /**
-     * Directly return an instance for `MonadState` that is based on this `Ref`
+     * Directly return an instance for `Stateful` that is based on this `Ref`
      *
      * Returned instance would use `get`/`set` methods of this `Ref` to manipulate state
      *
      * @see [[runState]] for potentially more convenient usage
      */
-    def stateInstance(implicit F: Monad[F]): MonadState[F, A] =
+    def stateInstance(implicit F: Monad[F]): Stateful[F, A] =
       runState(identity)
 
     /**
@@ -49,9 +49,9 @@ package object effects {
      * {{{
      *   case class RequestId(text: String)
      *
-     *   def greet[F[_]: Sync: ApplicativeAsk[?[_], RequestId]](name: String): F[String] =
+     *   def greet[F[_]: Sync: Ask[?[_], RequestId]](name: String): F[String] =
      *     for {
-     *       rId <- ApplicativeAsk.askF[F]()
+     *       rId <- Ask.askF[F]()
      *       _   <- Sync[F].delay(println(s"Handling request \$rId"))
      *     } yield s"Hello, \$name"
      *
@@ -65,17 +65,17 @@ package object effects {
      *   } yield res
      * }}}
      */
-    def runAsk[B](f: ApplicativeAsk[F, A] => B)(implicit F: Applicative[F]): B =
-      f(new RefApplicativeAsk(self))
+    def runAsk[B](f: Ask[F, A] => B)(implicit F: Applicative[F]): B =
+      f(new RefAsk(self))
 
     /**
-     * Directly return an instance for `ApplicativeAsk` that is based on this `Ref`
+     * Directly return an instance for `Ask` that is based on this `Ref`
      *
      * Returned instance would use `get` method of this `Ref` to provide a value
      *
      * @see [[runAsk]] for potentially more convenient usage
      */
-    def askInstance(implicit F: Applicative[F]): ApplicativeAsk[F, A] =
+    def askInstance(implicit F: Applicative[F]): Ask[F, A] =
       runAsk(identity)
 
     /**
@@ -86,7 +86,7 @@ package object effects {
      * `Writer` monad, initial (zero) is not required.
      *
      * {{{
-     *   def generateUser[F[_]: Sync: FunctorTell[?[_], String]](login: String) =
+     *   def generateUser[F[_]: Sync: Tell[?[_], String]](login: String) =
      *     for {
      *       _   <- tellF[F](s"Starting key generation for \$login")
      *       pwd <- IO(Random.alphanumeric.take(16).mkString)
@@ -108,18 +108,18 @@ package object effects {
      *      on each `tell`
      *
      */
-    def runTell[B](f: FunctorTell[F, A] => B)(implicit F: Functor[F], A: Semigroup[A]): B =
-      f(new RefFunctorTell(self))
+    def runTell[B](f: Tell[F, A] => B)(implicit F: Functor[F], A: Semigroup[A]): B =
+      f(new RefTell(self))
 
     /**
-     * Directly return an instance for `FunctorTell` that is based on this `Ref`
+     * Directly return an instance for `Tell` that is based on this `Ref`
      *
      * Returned instance would use `modify` method of this `Ref` and a `Semigroup`
      * to accumulate results
      *
      * @see [[runTell]] for potentially more convenient usage
      */
-    def tellInstance(implicit F: Functor[F], A: Semigroup[A]): FunctorTell[F, A] =
+    def tellInstance(implicit F: Functor[F], A: Semigroup[A]): Tell[F, A] =
       runTell(identity)
   }
 }

--- a/effects/src/main/scala/com/olegpy/meow/internal/CatsEffectMtlInstances.scala
+++ b/effects/src/main/scala/com/olegpy/meow/internal/CatsEffectMtlInstances.scala
@@ -8,23 +8,23 @@ import cats.syntax.semigroup._
 import cats.{Applicative, Functor, Monad}
 
 private[meow] object CatsEffectMtlInstances {
-  class RefMonadState[F[_]: Monad, S](ref: Ref[F, S]) extends MonadState[F, S] {
+  class RefStateful[F[_]: Monad, S](ref: Ref[F, S]) extends Stateful[F, S] {
     val monad: Monad[F] = implicitly
     def get: F[S] = ref.get
     def set(s: S): F[Unit] = ref.set(s)
-    def inspect[A](f: S => A): F[A] = ref.get.map(f)
-    def modify(f: S => S): F[Unit] = ref.update(f)
+    override def inspect[A](f: S => A): F[A] = ref.get.map(f)
+    override def modify(f: S => S): F[Unit] = ref.update(f)
   }
 
-  class RefFunctorTell[F[_]: Functor, L: Semigroup](ref: Ref[F, L])
-    extends FunctorTell[F, L] with DefaultFunctorTell[F, L] {
+  class RefTell[F[_]: Functor, L: Semigroup](ref: Ref[F, L])
+    extends Tell[F, L] {
     val functor: Functor[F] = implicitly
     def tell(l: L): F[Unit] = ref.update(_ |+| l)
   }
 
-  class RefApplicativeAsk[F[_]: Applicative, S](ref: Ref[F, S])
-    extends ApplicativeAsk[F, S] with DefaultApplicativeAsk[F, S] {
+  class RefAsk[F[_]: Applicative, S](ref: Ref[F, S])
+    extends Ask[F, S] {
     val applicative: Applicative[F] = implicitly
-    def ask: F[S] = ref.get
+    def ask[S2 >: S]: F[S2] = ref.get.widen
   }
 }

--- a/effects/src/test/scala/com/olegpy/meow/effects/EffectInstancesLawsSuite.scala
+++ b/effects/src/test/scala/com/olegpy/meow/effects/EffectInstancesLawsSuite.scala
@@ -25,19 +25,19 @@ object EffectInstancesLawsSuite extends SimpleTestSuite with Checkers {
 
   checkAll("Ref.runAsk") { implicit ctx =>
     Ref.unsafe[IO, Int](0).runAsk(ev =>
-      ApplicativeAskTests(ev).applicativeAsk[Int]
+      AskTests(ev).ask[Int]
     )
   }
 
   checkAll("Ref.runState") { implicit ctx =>
     Ref.unsafe[IO, Int](0).runState(ev =>
-      MonadStateTests(ev).monadState[Int]
+      StatefulTests(ev).stateful[Int]
     )
   }
 
   checkAll("Ref.runTell") { implicit ctx =>
     Ref.unsafe[IO, Int](0).runTell(ev =>
-      FunctorTellTests(ev).functorTell[Int]
+      TellTests(ev).tell[Int]
     )
   }
 
@@ -47,7 +47,7 @@ object EffectInstancesLawsSuite extends SimpleTestSuite with Checkers {
       if (x == 1) IO.raiseError[Unit](DummyErr)
       else IO.unit
     Consumer(fun _).runTell(ev =>
-      FunctorTellTests(ev).functorTell[Int]
+      TellTests(ev).tell[Int]
     )
 
   }

--- a/monix/src/main/scala/com/olegpy/meow/internal/MonixMtlInstances.scala
+++ b/monix/src/main/scala/com/olegpy/meow/internal/MonixMtlInstances.scala
@@ -3,31 +3,31 @@ package com.olegpy.meow.internal
 import cats.Semigroup
 import cats.syntax.semigroup._
 import cats.{Applicative, Functor, Monad}
-import cats.mtl.{ApplicativeLocal, DefaultFunctorTell, DefaultMonadState}
+import cats.mtl.{Local, Tell, Stateful}
 import monix.eval.TaskLocal
 import monix.eval.Task
 
 private[meow] object MonixMtlInstances {
-  class TaskLocalApplicativeLocal[E](taskLocal: TaskLocal[E])
-    extends ApplicativeLocal[Task, E] {
-    override def local[A](f: E => E)(fa: Task[A]): Task[A] =
+  class TaskLocalLocal[E](taskLocal: TaskLocal[E])
+    extends Local[Task, E] {
+    override def local[A](fa: Task[A])(f: E => E): Task[A] =
       taskLocal.bindL(taskLocal.read map f)(fa)
 
-    override def scope[A](e: E)(fa: Task[A]): Task[A] = taskLocal.bind(e)(fa)
+    override def scope[A](fa: Task[A])(e: E): Task[A] = taskLocal.bind(e)(fa)
     override val applicative: Applicative[Task] = Task.catsAsync
-    override def ask: Task[E] = taskLocal.read
+    override def ask[E2 >: E]: Task[E2] = taskLocal.read
     override def reader[A](f: E => A): Task[A] = ask.map(f)
   }
 
-  class TaskLocalMonadState[S](taskLocal: TaskLocal[S])
-    extends DefaultMonadState[Task, S] {
+  class TaskLocalStateful[S](taskLocal: TaskLocal[S])
+    extends Stateful[Task, S] {
     override val monad: Monad[Task] = Task.catsAsync
     override def get: Task[S] = taskLocal.read
     override def set(s: S): Task[Unit] = taskLocal.write(s)
   }
 
-  class TaskLocalFunctorTell[E: Semigroup](taskLocal: TaskLocal[E])
-    extends DefaultFunctorTell[Task, E] {
+  class TaskLocalTell[E: Semigroup](taskLocal: TaskLocal[E])
+    extends Tell[Task, E] {
     override val functor: Functor[Task] = Task.catsAsync
     override def tell(l: E): Task[Unit] =
       taskLocal.read.flatMap(e => taskLocal.write(e |+| l))

--- a/monix/src/main/scala/com/olegpy/meow/monix/package.scala
+++ b/monix/src/main/scala/com/olegpy/meow/monix/package.scala
@@ -2,30 +2,30 @@ package com.olegpy.meow
 
 import _root_.monix.eval.{Task, TaskLocal}
 import cats.Semigroup
-import cats.mtl.{ApplicativeLocal, FunctorTell, MonadState}
+import cats.mtl.{Local, Tell, Stateful}
 import internal.MonixMtlInstances._
 
 /**
- * Provides FunctorTell, ApplicativeLocal and MonadState for TaskLocal
+ * Provides Tell, Local and Stateful for TaskLocal
  */
 package object monix {
   implicit class TaskLocalEffects[A](val self: TaskLocal[A]) {
-    def runState[B](f: MonadState[Task, A] => B): B =
-      f(new TaskLocalMonadState(self))
+    def runState[B](f: Stateful[Task, A] => B): B =
+      f(new TaskLocalStateful(self))
 
-    def stateInstance: MonadState[Task, A] =
+    def stateInstance: Stateful[Task, A] =
       runState(identity)
 
-    def runLocal[B](f: ApplicativeLocal[Task, A] => B): B =
-      f(new TaskLocalApplicativeLocal(self))
+    def runLocal[B](f: Local[Task, A] => B): B =
+      f(new TaskLocalLocal(self))
 
-    def localInstance: ApplicativeLocal[Task, A] =
+    def localInstance: Local[Task, A] =
       runLocal(identity)
 
-    def runTell[B](f: FunctorTell[Task, A] => B)(implicit A: Semigroup[A]): B =
-      f(new TaskLocalFunctorTell(self))
+    def runTell[B](f: Tell[Task, A] => B)(implicit A: Semigroup[A]): B =
+      f(new TaskLocalTell(self))
 
-    def tellInstance(implicit A: Semigroup[A]): FunctorTell[Task, A] =
+    def tellInstance(implicit A: Semigroup[A]): Tell[Task, A] =
       runTell(identity)
 
   }

--- a/monix/src/test/scala/com/olegpy/meow/monix/ExampleTest.scala
+++ b/monix/src/test/scala/com/olegpy/meow/monix/ExampleTest.scala
@@ -3,17 +3,17 @@ package com.olegpy.meow.monix
 import scala.util.Random
 
 import cats.Monad
-import cats.mtl.{ApplicativeAsk, ApplicativeLocal}
+import cats.mtl.{Ask, Local}
 import cats.implicits._
 import _root_.monix.eval.{Task, TaskLocal}
 
 // Compile-time test for doc example
 object ExampleTest {
-  def service[F[_]: Monad](greeting: String, print: String => F[Unit])(implicit ev: ApplicativeAsk[F, String]): F[Unit] =
+  def service[F[_]: Monad](greeting: String, print: String => F[Unit])(implicit ev: Ask[F, String]): F[Unit] =
     ev.ask.map(name => s"$greeting $name") >>= print
 
-  def middleware[F[_]: Monad, A](getName: F[String])(service: F[Unit])(implicit ev: ApplicativeLocal[F, String]) =
-    getName.flatMap(n => ev.scope(n)(service))
+  def middleware[F[_]: Monad, A](getName: F[String])(service: F[Unit])(implicit ev: Local[F, String]) =
+    getName.flatMap(n => ev.scope(service)(n))
 
   // Can be looking up something in external system, or random ID
   val getName = Task(if (Random.nextBoolean()) "Oleg" else "Olga")

--- a/monix/src/test/scala/com/olegpy/meow/monix/MonixInstancesLawsSuite.scala
+++ b/monix/src/test/scala/com/olegpy/meow/monix/MonixInstancesLawsSuite.scala
@@ -54,18 +54,18 @@ object MonixInstancesLawsSuite extends SimpleTestSuite with Checkers {
 
   checkAll("TaskLocal.runLocal") { implicit ctx =>
     unsafeTaskLocal().runLocal(ev =>
-      ApplicativeLocalTests(ev).applicativeLocal[Int, String])
+      LocalTests(ev).local[Int, String])
   }
 
   checkAll("TaskLocal.runState") { implicit ctx =>
     unsafeTaskLocal().runState(ev =>
-      MonadStateTests(ev).monadState[Int]
+      StatefulTests(ev).stateful[Int]
     )
   }
 
   checkAll("TaskLocal.runTell") { implicit ctx =>
     unsafeTaskLocal().runTell(ev =>
-      FunctorTellTests(ev).functorTell[Int]
+      TellTests(ev).tell[Int]
     )
   }
 }


### PR DESCRIPTION
So far the compile-time derivation suites don't compile (might have to do something with the fact that the MonadPartialOrder-based derivations are now in implicit scope by default), but everything else does. Laws and monix tests pass.

@oleg-py do you have any ideas on how to best approach the derivations now? I can do some thinking but maybe you already have something.